### PR TITLE
Fix player UI not refreshing after returning to background tab

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -26,6 +26,15 @@ class AudioPlayer {
         this.stopSaveInterval();
       }
     });
+
+    document.addEventListener('visibilitychange', () => {
+      if (!this.currentEpisode) return;
+      if (document.visibilityState === 'visible') {
+        this.emit('timeupdate', this.currentEpisode, this.audio.currentTime, this.audio.duration || 0);
+      } else {
+        this.saveState();
+      }
+    });
   }
 
   play(episode: Episode): void {


### PR DESCRIPTION
Browsers throttle timeupdate events when a tab is in the background,
causing the progress bar and time counter to show stale values when
the user returns. Add a visibilitychange listener that re-emits the
current playback state when the page becomes visible, and saves state
when the page becomes hidden.

Fixes #2

https://claude.ai/code/session_01EeyStUCh3zEvjy1HnA9HbZ