### PR TITLE
Add How I AI podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ Want your own podcast player? Here's how to set it up (no coding required):
    https://feeds.example.com/podcast2.xml
    ```
 3. Save the Gist (can be public or secret)
-4. Click the **"Raw"** button and copy the URL (it should look like `https://gist.githubusercontent.com/...`)
+4. Copy the Gist ID from the URL (e.g., `https://gist.github.com/YOUR-USERNAME/GIST-ID`) and form the raw URL like this:
+   ```
+   https://gist.githubusercontent.com/YOUR-USERNAME/GIST-ID/raw/feeds.txt
+   ```
+   Using this format (without a commit hash) ensures the workflow always fetches the latest version of your feed list.
 
 ### 3. Configure GitHub Pages
 


### PR DESCRIPTION
## Summary

- Added `https://anchor.fm/s/1035b1568/podcast/rss` (How I AI podcast) to the feed Gist
- Updated `FEED_GIST_URL` repo variable to use a non-pinned raw Gist URL, so future Gist edits take effect automatically without needing to update the variable
- Updated README to guide users toward the non-pinned URL format

## Test plan

- [ ] Verify the feed Gist now includes the How I AI RSS URL
- [ ] Confirm the build workflow fetches and includes How I AI episodes after merge

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)