### PR TITLE
Preserve line breaks in episode notes display

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -203,6 +203,7 @@ button {
   color: var(--color-text-secondary);
   line-height: 1.4;
   margin-top: var(--space-xs);
+  white-space: pre-wrap;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,6 +24,11 @@ export function formatDate(isoString: string): string {
 
 export function stripHtml(html: string): string {
   const div = document.createElement('div');
-  div.innerHTML = html;
-  return div.textContent ?? '';
+  // Preserve line breaks from block-level elements and <br> tags
+  div.innerHTML = html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n')
+    .replace(/<\/div>/gi, '\n')
+    .replace(/<\/li>/gi, '\n');
+  return (div.textContent ?? '').replace(/\n{3,}/g, '\n\n').trim();
 }


### PR DESCRIPTION
Replace block-level HTML tags and <br> with newlines before stripping
HTML, and add white-space: pre-wrap so those newlines render correctly.

https://claude.ai/code/session_01M6VXmYymmfAk9qgGCxi4wz