### PR TITLE
Fix feed list parsing to skip non-URL lines

### DIFF
--- a/scripts/fetch-feeds.ts
+++ b/scripts/fetch-feeds.ts
@@ -59,7 +59,7 @@ export async function fetchFeedList(gistUrl: string): Promise<string[]> {
   const urls = text
     .split('\n')
     .map((line) => line.trim())
-    .filter((line) => line.length > 0 && !line.startsWith('#'));
+    .filter((line) => line.startsWith('http://') || line.startsWith('https://'));
 
   if (urls.length === 0) {
     throw new Error('Feed list Gist is empty (no URLs found)');


### PR DESCRIPTION
The feeds.txt gist has a plain-text title line ("List of podcast feeds
for Typod") that was being passed through as a feed URL, causing a
TypeError: Invalid URL. Updated the filter to only accept lines that
start with http:// or https://, which implicitly handles empty lines,
comments, and any other non-URL content.

https://claude.ai/code/session_012vE99dTiwZih8jKnBWzhbs